### PR TITLE
Update cli-test.js

### DIFF
--- a/bin/cli-test.js
+++ b/bin/cli-test.js
@@ -358,14 +358,12 @@ function initMe() {
         infoLog(`Using trust store: ${trustStorePath}`);
     }
 
-    if ( util.isNullOrUndefined(program.serverport)) {
-        program.serverport = 'localhost:5555';
-    }
-
-    let ar = program.serverport.split(':');
-    if ( ar.length == 2 ) {                    
-        config.http.hostname = ar[0];
-        config.http.port = ar[1];
+    if ( !util.isNullOrUndefined(program.serverport)) {
+        let ar = program.serverport.split(':');
+        if ( ar.length == 2 ) {                    
+            config.http.hostname = ar[0];
+            config.http.port = ar[1];
+        }
     }
 
     if ( !util.isNullOrUndefined(program.user) ) {


### PR DESCRIPTION
This change is for the 'is-client' command to pick serverport from 'config.js' file located in 'lib' folder if arguments for -s option is not specified while the command is executed.